### PR TITLE
Makefile: use pthread instead of lthread

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-g -Wall -lpthread -O3
+CFLAGS=-g -Wall -pthread -O3
 
 jitterdebugger: jitterdebugger.c
 


### PR DESCRIPTION
Hi Daniel,

I was getting undefined reference to pthread_xxx :)

Regards