### PR TITLE
srt_announce: add SENDER and NAME keys to announce template and add a…

### DIFF
--- a/README
+++ b/README
@@ -20,13 +20,15 @@ The group is called
 
 	[linux-stable-rt/origin/v4.4-rt]
 
-srt expects five keys
+srt expects the following keys
 
 	LOCALVERSION
 	GPG_KEY_ID
 	PRJ_GIT_TREE
 	PRJ_DIR
 	ANNOUNCE
+	SENDER
+	NAME
 
 LOCALVERSION: The filename of the localversion file, localversion-rt
 GPG_KEY_ID: ID of the GPG which should be used to sign and upload to korg
@@ -35,7 +37,8 @@ PRJ_DIR: kup folder to upload the release
 ANNOUNCE: Email template for release
 RC_TEXT: Email template for release candicate
 MAIL_TO: Email addresses to which the announces/patches should be send
-
+SENDER: Your name and email address
+NAME:  Your first name or nickname
 
 Note for each branch you need to define a group (-rt, -rebase, -next)
 
@@ -43,7 +46,7 @@ Note for each branch you need to define a group (-rt, -rebase, -next)
 Examples Configuration
 ----------------------
 [DEFAULT]
-MAIL_TO = LKML <linux-kernel@vger.kernel.org>,linux-rt-users <linux-rt-users@vger.kernel.org>,Steven Rostedt <rostedt@goodmis.org>,Thomas Gleixner <tglx@linutronix.de>,Carsten Emde <C.Emde@osadl.org>,John Kacur <jkacur@redhat.com>,Sebastian Andrzej Siewior <bigeasy@linutronix.de>,Daniel Wagner <daniel.wagner@siemens.com>,Tom Zanussi <tom.zanussi@linux.intel.com>,Julia Cartwright <julia@ni.com>
+MAIL_TO = LKML <linux-kernel@vger.kernel.org>,linux-rt-users <linux-rt-users@vger.kernel.org>,Steven Rostedt <rostedt@goodmis.org>,Thomas Gleixner <tglx@linutronix.de>,Carsten Emde <C.Emde@osadl.org>,John Kacur <jkacur@redhat.com>,Sebastian Andrzej Siewior <bigeasy@linutronix.de>,Daniel Wagner <daniel.wagner@siemens.com>,Tom Zanussi <tom.zanussi@linux.intel.com>,Clark Williams <williams@redhat.com>
 
 [linux-stable-rt/origin/v4.4-rt]
 LOCALVERSION = localversion-rt

--- a/announce-cip.txt
+++ b/announce-cip.txt
@@ -1,6 +1,7 @@
-From: Daniel Wagner <wagi@monom.org>
+From: {sender}
 Subject: [ANNOUNCE] {new_version}
-Data: {date}
+Date: {date}
+Message-ID: {message_id}
 To: cip-dev@lists.cip-project.org
 
 Hello CIP RT Folks!
@@ -15,7 +16,7 @@ You can get this release via the git tree at:
   Head SHA1: {branch_head}
 
 Enjoy!
-   Daniel
+   {name}
 
 Changes from v{old_version}:
 ---

--- a/announce-srt.txt
+++ b/announce-srt.txt
@@ -1,9 +1,10 @@
-From: Daniel Wagner <wagi@monom.org>
+From: {sender}
 Subject: [ANNOUNCE] {new_version}
-Data: {date}
+Date: {date}
+Message-ID: {message_id}
 To: {mail_to}
 
-Hello RT Folks!
+Hello RT-list!
 
 I'm pleased to announce the {new_version} stable release.
 
@@ -28,7 +29,7 @@ You can also build from {old_version} by applying the incremental patch:
   https://www.kernel.org{prj_dir}/incr/patch-{old_version}-rt{new_tag_rt}.patch.xz
 
 Enjoy!
-   Daniel
+{name}
 
 Changes from v{old_version}:
 ---

--- a/stable_rt_tools/srt_announce.py
+++ b/stable_rt_tools/srt_announce.py
@@ -26,6 +26,7 @@
 import os
 from time import gmtime, strftime
 from datetime import date, timedelta
+from email.utils import make_msgid
 
 from stable_rt_tools.srt_util import (confirm, get_local_branch_name,
                                       get_remote_branch_name, cmd)
@@ -56,6 +57,9 @@ def cover_letter_replacements(config, ctx):
          "new_version" : ctx.new_short_tag,
          "old_version" : ctx.old_short_tag,
          "prj_dir" : config['PRJ_DIR'],
+         "message_id" : make_msgid(),
+         "sender" : config['SENDER'],
+         "name" : config['NAME'],
          "new_tag_rt" : ctx.new_tag.rt}
     if ctx.is_rc:
         r["new_tag_rc"] = ctx.new_tag.rc


### PR DESCRIPTION
… message-id

Modify the announce template to use a SENDER and NAME key to
keep it generic. Generate and add a Message-ID header to keep
tglx happy.

Signed-off-by: Clark Williams <williams@redhat.com>