### PR TITLE
Drop old archaic features

### DIFF
--- a/stable_rt_tools/announce-srt-rc.txt
+++ b/stable_rt_tools/announce-srt-rc.txt
@@ -21,12 +21,7 @@ To build {new_version} directly, the following patches should be applied:
 
   https://www.kernel.org/pub/linux/kernel/v{major}.x/patch-{major}.{minor}.{patch}.xz
 
-  https://www.kernel.org{prj_dir}/patch-{new_version}.patch.xz
-
-
-You can also build from {old_version} by applying the incremental patch:
-
-  https://www.kernel.org{prj_dir}/incr/patch-{old_version}-rt{new_tag_rt}-rc{new_tag_rc}.patch.xz
+  https://www.kernel.org{prj_dir}/older/patch-{new_version}.patch.xz
 
 Signing key fingerprint:
 

--- a/stable_rt_tools/announce-srt.txt
+++ b/stable_rt_tools/announce-srt.txt
@@ -21,12 +21,7 @@ Or to build {new_version} directly, the following patches should be applied:
 
   https://www.kernel.org/pub/linux/kernel/v{major}.x/patch-{major}.{minor}.{patch}.xz
 
-  https://www.kernel.org{prj_dir}/patch-{new_version}.patch.xz
-
-
-You can also build from {old_version} by applying the incremental patch:
-
-  https://www.kernel.org{prj_dir}/incr/patch-{old_version}-rt{new_tag_rt}.patch.xz
+  https://www.kernel.org{prj_dir}/older/patch-{new_version}.patch.xz
 
 Signing key fingerprint:
 

--- a/stable_rt_tools/srt_create.py
+++ b/stable_rt_tools/srt_create.py
@@ -73,9 +73,6 @@ def create(config, ctx):
 
     create_tar_file(ctx.new_dir_patches, ctx.new_fln_tar)
 
-    if ctx.fln_incr:
-        create_patch_file(str(ctx.old_tag), str(ctx.new_tag), ctx.fln_incr)
-
     print('Created the following files in {0}'.format(ctx.new_dir_patches))
     for f in ctx.get_files():
         print('\t{0}'.format(f))

--- a/stable_rt_tools/srt_upload.py
+++ b/stable_rt_tools/srt_upload.py
@@ -40,21 +40,17 @@ def upload(config, ctx):
 
     path = config['PRJ_DIR']
     older_path = path + '/' + 'older'
-    incr_path = path + '/' + 'incr'
 
     kup = ['kup']
 
+    # upload files to archive
     for i, f in enumerate(ctx.get_files()):
         basename = os.path.splitext(f)[0]
-        if i == 2:
-            kup.extend(['put', basename + '.xz', basename + '.sign',
-                        incr_path + '/', '--'])
-        else:
-            kup.extend(['put', basename + '.xz', basename + '.sign',
-                        older_path + '/', '--'])
+        kup.extend(['put', basename + '.xz', basename + '.sign',
+                    older_path + '/', '--'])
 
-    # skip incr_file
-    for f in ctx.get_files()[:2]:
+    # create links from archive to latest dir.
+    for f in ctx.get_files():
         kup.extend(['ln', older_path + '/' + os.path.basename(f), '../', '--'])
 
     # If we're uploading an -rc release, don't delete the old release.

--- a/stable_rt_tools/srt_upload.py
+++ b/stable_rt_tools/srt_upload.py
@@ -53,12 +53,9 @@ def upload(config, ctx):
     for f in ctx.get_files():
         kup.extend(['ln', older_path + '/' + os.path.basename(f), '../', '--'])
 
-    # If we're uploading an -rc release, don't delete the old release.
-    if not ctx.is_rc:
-        kup.extend(['rm', path + '/' + os.path.basename(ctx.old_fln_patch),
-                    '--'])
-        kup.extend(['rm', path + '/' + os.path.basename(ctx.old_fln_tar),
-                    '--'])
+    # remove previous release from latest dir
+    for f in ctx.get_old_files():
+        kup.extend(['rm', path + '/' + os.path.basename(f), '--'])
 
     kup.extend(['ls', path])
 

--- a/stable_rt_tools/srt_util_context.py
+++ b/stable_rt_tools/srt_util_context.py
@@ -34,7 +34,6 @@ from stable_rt_tools.srt_util import (get_last_tag, get_old_tag,
 class SrtContext:
     def __init__(self, args, path=os.getcwd()):
         self.is_rc = False
-        self.fln_incr = None
         self.path = path
 
         old_tag = None
@@ -77,10 +76,6 @@ class SrtContext:
             if self.new_tag.is_rc:
                 postfix = '-rt{0}-rc{1}'.format(self.new_tag.rt,
                                                 self.new_tag.rc)
-            self.fln_incr = ('{0}/patch-{1}{2}.patch.xz'.
-                             format(self.new_dir_patches,
-                                    self.old_short_tag,
-                                    postfix))
             self.is_rc = self.new_tag.is_rc
 
     def __getattr__(self, name):
@@ -91,10 +86,7 @@ class SrtContext:
         return value
 
     def get_files(self):
-        files = [self.new_fln_patch, self.new_fln_tar]
-        if self.fln_incr:
-            files.append(self.fln_incr)
-        return files
+        return [self.new_fln_patch, self.new_fln_tar]
 
     def _dump(self):
         out = '\n'

--- a/stable_rt_tools/srt_util_context.py
+++ b/stable_rt_tools/srt_util_context.py
@@ -88,6 +88,9 @@ class SrtContext:
     def get_files(self):
         return [self.new_fln_patch, self.new_fln_tar]
 
+    def get_old_files(self):
+        return [self.old_fln_patch, self.old_fln_tar]
+
     def _dump(self):
         out = '\n'
         for key, val in self.__dict__.items():

--- a/stable_rt_tools/tests/test_srt.py
+++ b/stable_rt_tools/tests/test_srt.py
@@ -479,6 +479,10 @@ class TestReleaseCanditate(TestSrtBase):
 
                 'ln', prj + '/older/patch-4.4.14-rt5-rc1.patch.xz', '../', '--',
                 'ln', prj + '/older/patches-4.4.14-rt5-rc1.tar.xz', '../', '--',
+
+                'rm', prj + '/patch-4.4.14-rt4.patch.xz', '--',
+                'rm', prj + '/patches-4.4.14-rt4.tar.xz', '--',
+
                 'ls', prj]
         msg = '{0}\nOK to commit? (y/n): '.format(pformat(args))
         self.maxDiff = None

--- a/stable_rt_tools/tests/test_srt.py
+++ b/stable_rt_tools/tests/test_srt.py
@@ -477,11 +477,6 @@ class TestReleaseCanditate(TestSrtBase):
                 path + 'patches-4.4.14-rt5-rc1.tar.sign',
                 prj + '/older/', '--',
 
-                'put',
-                path + 'patch-4.4.14-rt4-rt5-rc1.patch.xz',
-                path + 'patch-4.4.14-rt4-rt5-rc1.patch.sign',
-                prj + '/incr/', '--',
-
                 'ln', prj + '/older/patch-4.4.14-rt5-rc1.patch.xz', '../', '--',
                 'ln', prj + '/older/patches-4.4.14-rt5-rc1.tar.xz', '../', '--',
                 'ls', prj]

--- a/stable_rt_tools/tests/test_srt_util_context.py
+++ b/stable_rt_tools/tests/test_srt_util_context.py
@@ -49,24 +49,17 @@ class TestSrtContext(TestCase):
         self.assertEqual(ctx.new_fln_tar,
                          '/tmp/patches/v4.4.115-rt38/patches-4.4.115-rt38.tar.xz')
 
-    def test_incr(self):
-        ctx = SrtContext(make_args('v4.4.115-rt38', 'v4.4.115-rt39'), '/tmp')
-        fname = ('/tmp/patches/v4.4.115-rt39/' +
-                 'patch-4.4.115-rt38-rt39.patch.xz')
-        self.assertEqual(ctx.fln_incr, fname)
-
     def test_is_rc(self):
         ctx = SrtContext(make_args('v4.4.115-rt38', 'v4.4.115-rt39-rc1'), '/tmp')
-        fname = ('/tmp/patches/v4.4.115-rt39-rc1/' +
-                 'patch-4.4.115-rt38-rt39-rc1.patch.xz')
-        self.assertEqual(ctx.fln_incr, fname)
-        self.assertEqual(ctx.is_rc, True)
+        path = '/tmp/patches/v4.4.115-rt39-rc1/'
+        files = [path + 'patch-4.4.115-rt39-rc1.patch.xz',
+                 path + 'patches-4.4.115-rt39-rc1.tar.xz']
+        self.assertEqual(ctx.get_files(), files)
 
     def test_get_files(self):
         ctx = SrtContext(make_args('v4.4.115-rt38', 'v4.4.115-rt39'), '/tmp')
 
         path = '/tmp/patches/v4.4.115-rt39/'
         files = [path + 'patch-4.4.115-rt39.patch.xz',
-                 path + 'patches-4.4.115-rt39.tar.xz',
-                 path + 'patch-4.4.115-rt38-rt39.patch.xz']
+                 path + 'patches-4.4.115-rt39.tar.xz']
         self.assertEqual(ctx.get_files(), files)


### PR DESCRIPTION
As discussed in last stable-rt telco I removed some of the old/strange features from the tool.

 - incremental patches
 - announcement templates do not mention incremental patches anymore
 - announcement templates use the archive URL for the patch
 - always remove the old version in the latest directory, this includes the release candidates.