### PR TITLE
Fix scope issue in srt.py where a sub_cmd is not defined.

### DIFF
--- a/stable_rt_tools/srt.py
+++ b/stable_rt_tools/srt.py
@@ -34,6 +34,16 @@ from stable_rt_tools import srt_sign
 from stable_rt_tools import srt_tag
 from stable_rt_tools import srt_upload
 
+sub_cmd = {
+    'commit': srt_commit,
+    'tag': srt_tag,
+    'create': srt_create,
+    'sign': srt_sign,
+    'upload': srt_upload,
+    'push': srt_push,
+    'announce': srt_announce,
+}
+
 
 def srt_get_argparser():
     parser = argparse.ArgumentParser(description='srt - stable -rt tool')
@@ -42,16 +52,6 @@ def srt_get_argparser():
                         help='Enable debug logging')
 
     subparser = parser.add_subparsers(help='sub command help', dest='cmd')
-
-    sub_cmd = {
-        'commit': srt_commit,
-        'tag': srt_tag,
-        'create': srt_create,
-        'sign': srt_sign,
-        'upload': srt_upload,
-        'push': srt_push,
-        'announce': srt_announce,
-    }
 
     for _,cmd in sub_cmd.items():
         cmd.add_argparser(subparser)


### PR DESCRIPTION
srt commit fails with the following error:
:~/work/v4.9-rt$ srt commit
Traceback (most recent call last):
  File "/usr/local/bin/srt", line 11, in <module>
    load_entry_point('stable-rt-tools==0.1', 'console_scripts', 'srt')()
  File
"/usr/local/lib/python3.8/dist-packages/stable_rt_tools-0.1-py3.8.egg/stable_rt_tools/srt.py",
line 70, in main
    if args.cmd in sub_cmd:
NameError: name 'sub_cmd' is not defined

The quick fix was to make the sub_cmd dict a global.

Signed-off-by: Mark Gross <markgross@kernel.org>