### PR TITLE
prep: implement prep state persistence and context usage

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -354,7 +354,7 @@ Create a new release
   $ git pull
 
   $ cd v6.12-rt
-  $ source <(srt prep)
+  $ srt prep
 
   $ cd v6.12
   $ while quilt push; do; quilt refresh; done
@@ -385,6 +385,12 @@ Create a new release
 
   $ srt announce > ../announce-rt
   $ mutt -H ../announce-rt
+
+The ``srt prep`` command stores release state in git metadata shared by the
+worktrees. Commands such as ``srt patches``, ``srt create``, ``srt sign``,
+``srt upload`` and ``srt push`` read this state automatically when tags are
+not provided explicitly. ``srt push`` clears the state after a successful push.
+If a workflow gets interrupted, clear it manually with ``srt prep --clear``.
 
 
 Trouble shooting

--- a/stable_rt_tools/srt_prep.py
+++ b/stable_rt_tools/srt_prep.py
@@ -25,7 +25,8 @@
 
 import os
 from stable_rt_tools.srt_util import (
-    get_remote_branch_name, get_old_tag, get_config, get_last_rt_tag, cmd
+    get_remote_branch_name, get_old_tag, get_config, get_last_rt_tag, cmd,
+    write_srt_state, clear_srt_state, get_workflow_branch, is_quilt_workflow
 )
 
 
@@ -64,6 +65,15 @@ def prep(config):
     next_stable = get_next_stable_version(branch_name, stable_tree_dir)
     new_tag = f"{next_stable}-rt{rt_ver}"
 
+    write_srt_state({
+        'old_tag': old_tag,
+        'new_tag': new_tag,
+        'quilt_patches': quilt_patches,
+        'branch': branch_name,
+        'workflow_branch': get_workflow_branch(branch_name),
+        'quilt_workflow': is_quilt_workflow(config),
+    })
+
     print(f"export QUILT_PATCHES={quilt_patches}")
     print(f"export OLD_TAG={old_tag}")
     print(f"export NEW_TAG={new_tag}")
@@ -71,8 +81,13 @@ def prep(config):
 
 def add_argparser(parser):
     prs = parser.add_parser('prep')
+    prs.add_argument('--clear', action='store_true',
+                     help='Clear saved srt prep state')
     return prs
 
 
 def execute(args):
+    if getattr(args, 'clear', False):
+        clear_srt_state()
+        return
     prep(get_config())

--- a/stable_rt_tools/srt_push.py
+++ b/stable_rt_tools/srt_push.py
@@ -24,7 +24,7 @@
 
 from stable_rt_tools.srt_util import (check_context, cmd, confirm, get_config,
                                       get_remote_branch_name,
-                                      is_quilt_workflow)
+                                      is_quilt_workflow, clear_srt_state)
 from stable_rt_tools.srt_util_context import SrtContext
 
 
@@ -58,6 +58,7 @@ def push(config, ctx):
 
     if confirm('OK to push?'):
         cmd(gcp + args)
+        clear_srt_state()
 
 
 def add_argparser(parser):

--- a/stable_rt_tools/srt_util.py
+++ b/stable_rt_tools/srt_util.py
@@ -25,6 +25,8 @@
 import os
 import re
 import sys
+import json
+from datetime import datetime, timezone
 from configparser import ConfigParser
 
 from logging import debug, error
@@ -58,6 +60,13 @@ def get_remote_branch_name(short=True):
     if short:
         return name.split('/')[1]
     return name
+
+
+def get_workflow_branch(branch_name):
+    for suffix in ('-patches', '-rebase', '-next'):
+        if branch_name.endswith(suffix):
+            return branch_name[:-len(suffix)]
+    return branch_name
 
 
 def tag_exists(tag):
@@ -146,6 +155,58 @@ def get_old_tag():
     if last_rc is not None:
         tag += '-rc{}'.format(last_rc)
     return tag
+
+
+def get_git_common_dir(path=None):
+    base = path if path else os.getcwd()
+    common_dir = cmd(['git', '-C', base, 'rev-parse', '--git-common-dir'])
+    if os.path.isabs(common_dir):
+        return common_dir
+    return os.path.abspath(os.path.join(base, common_dir))
+
+
+def get_srt_state_path(path=None):
+    return os.path.join(get_git_common_dir(path), 'srt', 'state.json')
+
+
+def read_srt_state(path=None):
+    state_path = get_srt_state_path(path)
+    if not os.path.exists(state_path):
+        return None
+    with open(state_path, 'r') as f:
+        return json.load(f)
+
+
+def write_srt_state(state, path=None):
+    state_path = get_srt_state_path(path)
+    os.makedirs(os.path.dirname(state_path), exist_ok=True)
+    state = dict(state)
+    state['updated_at'] = datetime.now(timezone.utc).isoformat()
+    with open(state_path, 'w') as f:
+        json.dump(state, f, sort_keys=True)
+
+
+def clear_srt_state(path=None):
+    state_path = get_srt_state_path(path)
+    if os.path.exists(state_path):
+        os.remove(state_path)
+
+
+def validate_srt_state(state, current_branch):
+    required = ['old_tag', 'new_tag', 'workflow_branch']
+    missing = [k for k in required if not state.get(k)]
+    if missing:
+        return ('srt state is invalid (missing: {}). '
+                'Run "srt prep --clear" and then "srt prep".'
+                .format(', '.join(missing)))
+
+    expected_workflow = state['workflow_branch']
+    current_workflow = get_workflow_branch(current_branch)
+    if expected_workflow != current_workflow:
+        return ('srt state is stale: prepared for workflow "{}" but current '
+                'workflow is "{}". Run "srt prep --clear" and then "srt prep".'
+                .format(expected_workflow, current_workflow))
+    return None
 
 
 def is_dirty():

--- a/stable_rt_tools/srt_util_context.py
+++ b/stable_rt_tools/srt_util_context.py
@@ -24,11 +24,26 @@
 
 
 import os
+import sys
 from logging import debug
 
 from stable_rt_tools.srt_util import (get_last_tag, get_old_tag,
-                                      get_remote_branch_name)
+                                      get_remote_branch_name, read_srt_state,
+                                      validate_srt_state)
 from stable_rt_tools.srt_util_tag import Tag
+
+
+def _read_and_validate_state(path):
+    state = read_srt_state(path)
+    if not state:
+        return None
+
+    current_branch = get_remote_branch_name()
+    err = validate_srt_state(state, current_branch)
+    if err:
+        print(err, file=sys.stderr)
+        sys.exit(1)
+    return state
 
 
 class SrtContext:
@@ -39,19 +54,29 @@ class SrtContext:
         old_tag = None
         new_tag = None
 
+        state = None
         if args and getattr(args, "OLD_TAG", None):
             old_tag = args.OLD_TAG
         elif os.environ.get("OLD_TAG"):
             old_tag = os.environ["OLD_TAG"]
         else:
-            old_tag = get_old_tag()
+            state = _read_and_validate_state(path)
+            if state:
+                old_tag = state.get('old_tag')
+            else:
+                old_tag = get_old_tag()
 
         if args and getattr(args, "NEW_TAG", None):
             new_tag = args.NEW_TAG
         elif os.environ.get("NEW_TAG"):
             new_tag = os.environ["NEW_TAG"]
         else:
-            new_tag = get_last_tag(get_remote_branch_name())
+            if state is None:
+                state = _read_and_validate_state(path)
+            if state:
+                new_tag = state.get('new_tag')
+            else:
+                new_tag = get_last_tag(get_remote_branch_name())
 
         self._add_tag('old', old_tag)
         self._add_tag('new', new_tag)

--- a/stable_rt_tools/tests/test_srt_prep.py
+++ b/stable_rt_tools/tests/test_srt_prep.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+#
+# srt - stable rt tooling
+#
+# Copyright (c) Siemens AG, 2026
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE
+
+import argparse
+from unittest import TestCase
+from unittest.mock import patch
+
+from stable_rt_tools.srt_prep import prep, execute
+
+
+class TestPrepState(TestCase):
+    def test_prep_writes_state(self):
+        config = {'quilt_workflow': 'true'}
+        with patch('stable_rt_tools.srt_prep.os.getcwd',
+                   return_value='/tmp/v6.12-rt'):
+            with patch('stable_rt_tools.srt_prep.get_old_tag',
+                       return_value='v6.12.79-rt17'):
+                with patch('stable_rt_tools.srt_prep.get_remote_branch_name',
+                           return_value='v6.12-rt'):
+                    with patch('stable_rt_tools.srt_prep.get_last_rt_tag',
+                               return_value='-rt17'):
+                        with patch(
+                            'stable_rt_tools.srt_prep.get_next_stable_version',
+                            return_value='v6.12.89'
+                        ):
+                            with patch(
+                                'stable_rt_tools.srt_prep.write_srt_state'
+                            ) as write_state:
+                                prep(config)
+                                write_state.assert_called_once()
+                                state = write_state.call_args[0][0]
+                                self.assertEqual(
+                                    state['old_tag'], 'v6.12.79-rt17')
+                                self.assertEqual(
+                                    state['new_tag'], 'v6.12.89-rt18')
+                                self.assertEqual(
+                                    state['workflow_branch'], 'v6.12-rt')
+
+    def test_clear_state(self):
+        args = argparse.Namespace(clear=True)
+        with patch('stable_rt_tools.srt_prep.clear_srt_state') as clear_state:
+            execute(args)
+            clear_state.assert_called_once()

--- a/stable_rt_tools/tests/test_srt_push.py
+++ b/stable_rt_tools/tests/test_srt_push.py
@@ -64,7 +64,11 @@ def test_push_quilt_workflow():
                 calls.append(args)
 
             with patch('stable_rt_tools.srt_push.cmd', side_effect=fake_cmd):
-                push(config, ctx)
+                with patch(
+                    'stable_rt_tools.srt_push.clear_srt_state'
+                ) as clear_state:
+                    push(config, ctx)
+                    clear_state.assert_called_once()
 
             push_calls = [c for c in calls if c[0:2] == ['git', 'push']]
             assert push_calls, 'No git push calls made'
@@ -76,6 +80,21 @@ def test_push_quilt_workflow():
             )
             assert found_branch, 'Did not push -rt-patches branch'
             assert found_tag, 'Did not push -patches tag'
+
+
+def test_push_does_not_clear_state_when_cancelled():
+    config = DummyConfig({'PRJ_GIT_TREE': 'origin'})
+    ctx = DummyCtx('v6.12.39-rt11', is_rc=False)
+
+    with patch('stable_rt_tools.srt_push.get_remote_branch_name',
+               return_value='v6.12-rt'):
+        with patch('stable_rt_tools.srt_push.confirm', return_value=False):
+            with patch('stable_rt_tools.srt_push.cmd'):
+                with patch(
+                    'stable_rt_tools.srt_push.clear_srt_state'
+                ) as clear_state:
+                    push(config, ctx)
+                    clear_state.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/stable_rt_tools/tests/test_srt_util_context.py
+++ b/stable_rt_tools/tests/test_srt_util_context.py
@@ -24,6 +24,7 @@
 
 import argparse
 from unittest import TestCase
+from unittest.mock import patch
 
 from stable_rt_tools.srt_util_context import SrtContext
 
@@ -61,3 +62,59 @@ class TestSrtContext(TestCase):
         files = [path + 'patch-4.4.115-rt39.patch.xz',
                  path + 'patches-4.4.115-rt39.tar.xz']
         self.assertEqual(ctx.get_files(), files)
+
+    def test_use_state_when_no_args_or_env(self):
+        state = {
+            'old_tag': 'v4.4.115-rt38',
+            'new_tag': 'v4.4.115-rt39',
+            'workflow_branch': 'v4.4-rt',
+        }
+        with patch('stable_rt_tools.srt_util_context.read_srt_state',
+                   return_value=state):
+            with patch(
+                'stable_rt_tools.srt_util_context.get_remote_branch_name',
+                return_value='v4.4-rt-patches'
+            ):
+                with patch('stable_rt_tools.srt_util_context.get_old_tag',
+                           return_value='v4.4.115-rt37'):
+                    with patch('stable_rt_tools.srt_util_context.get_last_tag',
+                               return_value='v4.4.115-rt38'):
+                        ctx = SrtContext(make_args(), '/tmp')
+                        self.assertEqual(str(ctx.old_tag), 'v4.4.115-rt38')
+                        self.assertEqual(str(ctx.new_tag), 'v4.4.115-rt39')
+
+    def test_cli_and_env_precedence_over_state(self):
+        state = {
+            'old_tag': 'v4.4.115-rt38',
+            'new_tag': 'v4.4.115-rt39',
+            'workflow_branch': 'v4.4-rt',
+        }
+        with patch('stable_rt_tools.srt_util_context.read_srt_state',
+                   return_value=state):
+            with patch(
+                'stable_rt_tools.srt_util_context.get_remote_branch_name',
+                return_value='v4.4-rt'
+            ):
+                with patch('stable_rt_tools.srt_util_context.os.environ',
+                           {'OLD_TAG': 'v4.4.115-rt40'}):
+                    ctx = SrtContext(
+                        make_args(old_tag='v4.4.115-rt41',
+                                  new_tag='v4.4.115-rt42'),
+                        '/tmp')
+                    self.assertEqual(str(ctx.old_tag), 'v4.4.115-rt41')
+                    self.assertEqual(str(ctx.new_tag), 'v4.4.115-rt42')
+
+    def test_stale_state_fails(self):
+        state = {
+            'old_tag': 'v4.4.115-rt38',
+            'new_tag': 'v4.4.115-rt39',
+            'workflow_branch': 'v4.4-rt',
+        }
+        with patch('stable_rt_tools.srt_util_context.read_srt_state',
+                   return_value=state):
+            with patch(
+                'stable_rt_tools.srt_util_context.get_remote_branch_name',
+                return_value='v6.12-rt'
+            ):
+                with self.assertRaises(SystemExit):
+                    SrtContext(make_args(), '/tmp')


### PR DESCRIPTION
Make the prep command a bit more usable by keeping the state in a file instead in the environment.